### PR TITLE
Add support to _not_ follow ldap referrals

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Example of a filter based on AD nested group:
   * define( 'LDAPAUTH_HOST', 'ldap://'); // LDAP protocol without the hostname. You can use 'ldaps://' for LDAP with TLS.
 
 ### To prevent following LDAP referrals
-  * define( 'LDAPAUTH_LDAP_OPT_REFERRALS', 0 ); // When using Active Directory, following LDAP referrals can fail.  It will fail in a way that causes the ldap_search function to hang for at least a minute.  Related [issue](https://github.com/MISP/MISP/issues/2749).
+  * define( 'LDAPAUTH_LDAP_OPT_REFERRALS', 0 ); // (optional) Defaults to 1.  When using Active Directory, following LDAP referrals can fail.  It will fail in a way that causes the ldap_search function to hang for at least a minute.  Related [issue](https://github.com/MISP/MISP/issues/2749).
 
 NOTE: This will require config.php to be writable by your webserver user. This function is now largely unneeded because the database-based cache offers similar benefits without the need to make config.php writable. It is retained for backward compatibility.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Example of a filter based on AD nested group:
   * define( 'LDAPAUTH_DNS_SITES_AND_SERVICES', '_ldap._tcp.corporate._sites.yourdomain.com' ); // If using Active Directory with multiple Domain Controllers, the safe way to use DNS to look up your active LDAP server names.  If set, it will be used to override the hostname portion of LDAPAUTH_HOST.
   * define( 'LDAPAUTH_HOST', 'ldap://'); // LDAP protocol without the hostname. You can use 'ldaps://' for LDAP with TLS.
 
+### To prevent following LDAP referrals
+  * define( 'LDAPAUTH_LDAP_OPT_REFERRALS', 0 ); // When using Active Directory, following LDAP referrals can fail.  It will fail in a way that causes the ldap_search function to hang for at least a minute.  Related [issue](https://github.com/MISP/MISP/issues/2749).
+
 NOTE: This will require config.php to be writable by your webserver user. This function is now largely unneeded because the database-based cache offers similar benefits without the need to make config.php writable. It is retained for backward compatibility.
 
 Troubleshooting

--- a/plugin.php
+++ b/plugin.php
@@ -198,6 +198,9 @@ function ldapauth_is_valid_user($value)
 		if (defined('LDAPAUTH_GROUP_ATTR'))
 			array_push($attrs, LDAPAUTH_GROUP_ATTR);
 
+		if (defined('LDAPAUTH_LDAP_OPT_REFERRALS')) {
+			ldap_set_option($ldapConnection, LDAP_OPT_REFERRALS, LDAPAUTH_LDAP_OPT_REFERRALS);
+		}
 		$searchDn = ldap_search($ldapConnection, LDAPAUTH_BASE, $ldapFilter, $attrs);
 		if (!$searchDn) return $value;
 		$searchResult = ldap_get_entries($ldapConnection, $searchDn);


### PR DESCRIPTION
 On Active Directory, ldap referrals can cause the ldap_search function to hang the the page to timeout.